### PR TITLE
Remove all 403-producing URLs

### DIFF
--- a/classified-cat-jp-images.txt
+++ b/classified-cat-jp-images.txt
@@ -18,12 +18,10 @@ https://cdn.pixabay.com/photo/2017/05/21/22/06/cat-2332444__480.jpg
 https://cdn.pixabay.com/photo/2014/03/30/23/35/cat-301720__480.jpg
 https://cdn.pixabay.com/photo/2017/05/21/22/07/cat-2332451__480.jpg
 https://cdn.pixabay.com/photo/2014/08/03/00/51/kitten-408798__480.jpg
-https://cdn.pixabay.com/photo/2017/05/11/07/27/cat-2303146__480.jpg
 https://cdn.pixabay.com/photo/2014/03/30/23/49/cat-301723__480.jpg
 https://cdn.pixabay.com/photo/2013/07/18/20/27/cat-165068__480.jpg
 https://cdn.pixabay.com/photo/2017/05/25/07/40/cat-2342562__480.jpg
 https://cdn.pixabay.com/photo/2017/05/30/22/27/british-shorthair-2358404__480.jpg
-https://cdn.pixabay.com/photo/2012/02/27/16/57/animal-17430__480.jpg
 https://cdn.pixabay.com/photo/2017/04/06/15/15/cat-2208535__480.jpg
 https://cdn.pixabay.com/photo/2017/05/18/10/57/cat-2323258__480.jpg
 https://cdn.pixabay.com/photo/2016/11/18/21/26/cat-1836936__480.jpg
@@ -68,7 +66,6 @@ https://cdn.pixabay.com/photo/2017/03/12/01/29/cats-2136245__480.jpg
 https://cdn.pixabay.com/photo/2017/05/29/10/30/kitten-2353403__480.jpg
 https://cdn.pixabay.com/photo/2017/05/15/09/59/cat-2314326__480.jpg
 https://cdn.pixabay.com/photo/2016/11/07/22/49/kitten-1807071__480.jpg
-https://cdn.pixabay.com/photo/2017/02/13/14/47/cat-2062790__480.jpg
 https://cdn.pixabay.com/photo/2016/12/16/20/44/cat-1912330__480.jpg
 https://cdn.pixabay.com/photo/2016/11/06/19/42/cat-1803904__480.jpg
 https://cdn.pixabay.com/photo/2016/11/15/12/36/cat-1826117__480.jpg
@@ -96,7 +93,6 @@ https://cdn.pixabay.com/photo/2016/12/30/17/27/cat-1941089__480.jpg
 https://cdn.pixabay.com/photo/2016/05/17/17/16/cat-1398627__480.jpg
 https://cdn.pixabay.com/photo/2016/09/18/12/29/cat-1678009__480.jpg
 https://cdn.pixabay.com/photo/2016/12/11/02/51/cat-1898678__480.jpg
-https://cdn.pixabay.com/photo/2017/02/23/16/26/cat-2092580__480.jpg
 https://cdn.pixabay.com/photo/2016/07/06/13/28/cat-1500498__480.jpg
 https://cdn.pixabay.com/photo/2016/10/18/13/44/cat-1750241__480.jpg
 https://cdn.pixabay.com/photo/2017/03/19/20/28/cat-2157497__480.jpg
@@ -114,7 +110,6 @@ https://cdn.pixabay.com/photo/2017/01/31/19/04/cat-2026479__480.jpg
 https://cdn.pixabay.com/photo/2016/12/11/02/45/cat-1898667__480.jpg
 https://cdn.pixabay.com/photo/2016/08/12/18/34/cat-1589369__480.jpg
 https://cdn.pixabay.com/photo/2016/12/10/13/00/cat-1897224__480.jpg
-https://cdn.pixabay.com/photo/2016/11/28/15/23/cat-1865263__480.jpg
 https://cdn.pixabay.com/photo/2016/10/05/15/58/cats-1716984__480.jpg
 https://cdn.pixabay.com/photo/2016/12/11/00/41/cat-1898510__480.jpg
 https://cdn.pixabay.com/photo/2016/08/13/21/53/cat-1591636__480.jpg
@@ -250,7 +245,6 @@ https://cdn.pixabay.com/photo/2016/08/29/14/43/cat-1628424__480.jpg
 https://cdn.pixabay.com/photo/2015/11/05/01/22/cat-1023576__480.jpg
 https://cdn.pixabay.com/photo/2016/12/09/16/11/cat-1895171__480.jpg
 https://cdn.pixabay.com/photo/2016/10/04/10/18/cat-1713960__480.jpg
-https://cdn.pixabay.com/photo/2016/11/09/20/34/kittens-1812641__480.jpg
 https://cdn.pixabay.com/photo/2016/05/29/10/20/cat-1422703__480.jpg
 https://cdn.pixabay.com/photo/2016/01/08/22/11/cat-1129372__480.jpg
 https://cdn.pixabay.com/photo/2014/02/25/17/41/cat-274443__480.jpg
@@ -261,7 +255,6 @@ https://cdn.pixabay.com/photo/2016/05/22/22/52/cat-1409382__480.jpg
 https://cdn.pixabay.com/photo/2016/05/04/09/57/cat-1371107__480.jpg
 https://cdn.pixabay.com/photo/2016/08/20/14/49/cat-1607652__480.jpg
 https://cdn.pixabay.com/photo/2016/02/07/15/44/cat-1185006__480.jpg
-https://cdn.pixabay.com/photo/2016/09/04/17/07/cat-1644545__480.jpg
 https://cdn.pixabay.com/photo/2016/05/07/21/07/cat-1378203__480.jpg
 https://cdn.pixabay.com/photo/2016/09/26/15/27/cat-1696199__480.jpg
 https://cdn.pixabay.com/photo/2014/12/16/15/41/cat-570459__480.jpg
@@ -277,7 +270,6 @@ https://cdn.pixabay.com/photo/2015/07/31/15/01/cat-869218__480.jpg
 https://cdn.pixabay.com/photo/2015/12/06/15/14/cat-1079583__480.jpg
 https://cdn.pixabay.com/photo/2015/04/13/22/05/cat-721357__480.jpg
 https://cdn.pixabay.com/photo/2016/06/19/11/14/cat-1466474__480.jpg
-https://cdn.pixabay.com/photo/2016/05/17/03/27/cat-1397342__480.jpg
 https://cdn.pixabay.com/photo/2015/11/08/18/05/cat-1034034__480.jpg
 https://cdn.pixabay.com/photo/2016/08/10/22/58/cat-1584537__480.jpg
 https://cdn.pixabay.com/photo/2015/03/09/07/23/young-cat-665133__480.jpg
@@ -297,7 +289,6 @@ https://cdn.pixabay.com/photo/2016/01/01/21/45/cat-1117141__480.jpg
 https://cdn.pixabay.com/photo/2016/08/07/20/43/cat-1577119__480.jpg
 https://cdn.pixabay.com/photo/2015/04/02/06/25/cat-mia-703411__480.jpg
 https://cdn.pixabay.com/photo/2016/08/03/12/34/cat-1566612__480.jpg
-https://cdn.pixabay.com/photo/2016/08/20/00/02/cat-1606607__480.jpg
 https://cdn.pixabay.com/photo/2015/07/29/22/29/cat-866667__480.jpg
 https://cdn.pixabay.com/photo/2016/02/12/16/21/cat-1196331__480.jpg
 https://cdn.pixabay.com/photo/2015/11/12/18/01/cat-1040722__480.jpg
@@ -305,17 +296,14 @@ https://cdn.pixabay.com/photo/2016/05/13/23/07/cat-1391126__480.jpg
 https://cdn.pixabay.com/photo/2015/07/07/01/54/dog-833957__480.jpg
 https://cdn.pixabay.com/photo/2016/02/05/20/43/cat-1181938__480.jpg
 https://cdn.pixabay.com/photo/2016/02/19/01/02/cat-1208510__480.jpg
-https://cdn.pixabay.com/photo/2015/12/15/05/22/cat-1093707__480.jpg
 https://cdn.pixabay.com/photo/2015/05/02/22/41/cat-750515__480.jpg
 https://cdn.pixabay.com/photo/2016/01/17/12/03/cat-1144799__480.jpg
-https://cdn.pixabay.com/photo/2015/11/24/08/29/hangover-1059663__480.jpg
 https://cdn.pixabay.com/photo/2015/08/09/11/39/animal-881447__480.jpg
 https://cdn.pixabay.com/photo/2015/11/12/18/35/cat-1040771__480.jpg
 https://cdn.pixabay.com/photo/2016/03/03/20/30/cat-1234968__480.jpg
 https://cdn.pixabay.com/photo/2016/07/26/13/53/cat-1542856__480.jpg
 https://cdn.pixabay.com/photo/2016/02/27/13/05/cat-1225500__480.jpg
 https://cdn.pixabay.com/photo/2015/05/11/22/23/cat-763213__480.jpg
-https://cdn.pixabay.com/photo/2016/09/30/16/19/abyssinian-cat-1705659__480.jpg
 https://cdn.pixabay.com/photo/2016/07/07/01/06/cat-1501706__480.jpg
 https://cdn.pixabay.com/photo/2016/10/01/20/31/cat-1708291__480.jpg
 https://cdn.pixabay.com/photo/2016/08/03/11/48/united-kingdom-shorthair-1566487__480.jpg
@@ -346,7 +334,6 @@ https://cdn.pixabay.com/photo/2014/09/18/19/19/black-cat-451269__480.jpg
 https://cdn.pixabay.com/photo/2014/10/05/19/08/pet-475670__480.jpg
 https://cdn.pixabay.com/photo/2016/04/12/20/25/cat-1325335__480.jpg
 https://cdn.pixabay.com/photo/2015/10/17/13/46/ice-992542__480.jpg
-https://cdn.pixabay.com/photo/2015/02/08/16/30/hangover-628724__480.jpg
 https://cdn.pixabay.com/photo/2015/11/20/21/30/cat-1053895__480.jpg
 https://cdn.pixabay.com/photo/2016/02/07/15/24/cat-1184976__480.jpg
 https://cdn.pixabay.com/photo/2015/03/04/11/30/british-shorthair-658689__480.jpg
@@ -356,15 +343,12 @@ https://cdn.pixabay.com/photo/2015/11/20/22/59/cat-1054032__480.jpg
 https://cdn.pixabay.com/photo/2016/10/17/16/21/cat-1748075__480.jpg
 https://cdn.pixabay.com/photo/2015/11/15/22/09/red-1044915__480.jpg
 https://cdn.pixabay.com/photo/2016/02/24/17/43/pet-1220392__480.jpg
-https://cdn.pixabay.com/photo/2015/12/22/02/05/cat-1103503__480.jpg
-https://cdn.pixabay.com/photo/2015/12/21/03/17/cat-1101995__480.jpg
 https://cdn.pixabay.com/photo/2016/06/04/14/09/cat-1435590__480.jpg
 https://cdn.pixabay.com/photo/2015/07/26/22/11/animal-861805__480.jpg
 https://cdn.pixabay.com/photo/2015/11/16/01/28/cat-1045081__480.jpg
 https://cdn.pixabay.com/photo/2016/03/04/21/10/cat-1236710__480.jpg
 https://cdn.pixabay.com/photo/2015/12/24/13/31/cat-1106803__480.jpg
 https://cdn.pixabay.com/photo/2016/04/11/20/46/cat-1322989__480.jpg
-https://cdn.pixabay.com/photo/2016/08/26/17/01/bobcat-1622664__480.jpg
 https://cdn.pixabay.com/photo/2016/08/13/00/58/cat-1590081__480.jpg
 https://cdn.pixabay.com/photo/2017/05/25/02/13/cat-2342055__480.jpg
 https://cdn.pixabay.com/photo/2015/12/09/19/20/cat-1085317__480.jpg
@@ -387,7 +371,6 @@ https://cdn.pixabay.com/photo/2016/10/02/16/14/kermit-1709861__480.jpg
 https://cdn.pixabay.com/photo/2015/11/12/18/44/cat-1040789__480.jpg
 https://cdn.pixabay.com/photo/2013/12/01/18/58/cat-222096__480.jpg
 https://cdn.pixabay.com/photo/2017/05/24/20/06/cat-2341464__480.jpg
-https://cdn.pixabay.com/photo/2016/07/10/02/34/cat-1507213__480.jpg
 https://cdn.pixabay.com/photo/2016/03/20/17/26/cat-1269039__480.jpg
 https://cdn.pixabay.com/photo/2015/09/16/20/53/pet-943388__480.jpg
 https://cdn.pixabay.com/photo/2016/05/06/12/23/cat-1375793__480.jpg
@@ -396,7 +379,6 @@ https://cdn.pixabay.com/photo/2017/06/01/15/14/cat-2363730__480.jpg
 https://cdn.pixabay.com/photo/2015/11/12/17/49/cat-1040690__480.jpg
 https://cdn.pixabay.com/photo/2015/12/12/21/23/cat-1090154__480.jpg
 https://cdn.pixabay.com/photo/2015/02/09/07/52/cat-629419__480.jpg
-https://cdn.pixabay.com/photo/2015/01/09/10/33/adidas-593924__480.jpg
 https://cdn.pixabay.com/photo/2015/07/07/20/21/cat-834836__480.jpg
 https://cdn.pixabay.com/photo/2015/02/08/12/19/pet-628400__480.jpg
 https://cdn.pixabay.com/photo/2016/02/05/16/31/wild-cat-1181440__480.jpg
@@ -485,9 +467,7 @@ https://cdn.pixabay.com/photo/2015/11/10/01/36/cat-1036190__480.jpg
 https://cdn.pixabay.com/photo/2016/05/08/11/32/cat-1379001__480.jpg
 https://cdn.pixabay.com/photo/2014/09/26/21/40/cat-462865__480.jpg
 https://cdn.pixabay.com/photo/2014/07/06/02/25/cat-385207__480.jpg
-https://cdn.pixabay.com/photo/2016/11/15/16/27/maine-coon-cat-1826775__480.jpg
 https://cdn.pixabay.com/photo/2014/05/13/09/12/cat-343293__480.jpg
-https://cdn.pixabay.com/photo/2014/04/13/15/21/hangover-323029__480.jpg
 https://cdn.pixabay.com/photo/2013/05/08/12/51/cat-109847__480.jpg
 https://cdn.pixabay.com/photo/2015/12/27/13/19/british-shorthair-1109781__480.jpg
 https://cdn.pixabay.com/photo/2013/05/25/16/03/cat-113607__480.jpg
@@ -526,7 +506,6 @@ https://cdn.pixabay.com/photo/2015/11/30/11/34/cat-1070137__480.jpg
 https://cdn.pixabay.com/photo/2013/08/25/15/24/baby-175740__480.jpg
 https://cdn.pixabay.com/photo/2014/08/03/02/12/kitten-408853__480.jpg
 https://cdn.pixabay.com/photo/2016/02/11/00/35/feline-1192935__480.jpg
-https://cdn.pixabay.com/photo/2014/12/20/15/42/pallas-cat-574031__480.jpg
 https://cdn.pixabay.com/photo/2015/02/24/00/27/cat-646937__480.jpg
 https://cdn.pixabay.com/photo/2016/03/29/18/36/cat-1288972__480.jpg
 https://cdn.pixabay.com/photo/2015/06/01/21/27/british-shorthair-794328__480.jpg
@@ -535,15 +514,12 @@ https://cdn.pixabay.com/photo/2015/02/24/00/33/cat-646940__480.jpg
 https://cdn.pixabay.com/photo/2014/09/15/08/21/cat-446638__480.jpg
 https://cdn.pixabay.com/photo/2016/04/25/12/42/cat-1351796__480.jpg
 https://cdn.pixabay.com/photo/2016/07/14/20/03/tabby-kitten-1517475__480.jpg
-https://cdn.pixabay.com/photo/2017/06/18/20/04/straw-bed-2417062__480.jpg
 https://cdn.pixabay.com/photo/2014/09/22/16/51/cat-456530__480.jpg
 https://cdn.pixabay.com/photo/2014/11/10/21/09/cat-525888__480.jpg
 https://cdn.pixabay.com/photo/2013/10/30/11/32/cat-202892__480.jpg
 https://cdn.pixabay.com/photo/2013/08/29/19/21/cat-177069__480.jpg
 https://cdn.pixabay.com/photo/2014/07/24/20/20/cat-401182__480.jpg
-https://cdn.pixabay.com/photo/2015/08/04/14/14/kittens-874773__480.jpg
 https://cdn.pixabay.com/photo/2015/08/20/13/56/cat-897411__480.jpg
-https://cdn.pixabay.com/photo/2014/11/18/08/18/european-shorthair-535806__480.jpg
 https://cdn.pixabay.com/photo/2013/03/25/10/32/cat-96659__480.jpg
 https://cdn.pixabay.com/photo/2012/02/15/14/45/cat-13296__480.jpg
 https://cdn.pixabay.com/photo/2015/06/01/21/26/british-shorthair-794325__480.jpg
@@ -574,7 +550,6 @@ https://cdn.pixabay.com/photo/2014/08/03/00/56/cat-408808__480.jpg
 https://cdn.pixabay.com/photo/2013/03/12/21/40/cat-93044__480.jpg
 https://cdn.pixabay.com/photo/2015/06/28/17/15/white-gray-brown-kitten-824674__480.jpg
 https://cdn.pixabay.com/photo/2013/10/16/20/25/cat-196475__480.jpg
-https://cdn.pixabay.com/photo/2014/11/05/17/28/savannah-cat-518126__480.jpg
 https://cdn.pixabay.com/photo/2012/11/07/17/17/cat-65141__480.jpg
 https://cdn.pixabay.com/photo/2015/08/09/19/04/cats-882051__480.jpg
 https://cdn.pixabay.com/photo/2015/01/23/15/00/cat-609136__480.jpg
@@ -586,7 +561,6 @@ https://cdn.pixabay.com/photo/2015/02/25/13/45/cat-648839__480.jpg
 https://cdn.pixabay.com/photo/2013/10/28/19/23/cat-201969__480.jpg
 https://cdn.pixabay.com/photo/2011/03/16/15/50/cat-5331__480.jpg
 https://cdn.pixabay.com/photo/2015/12/01/09/28/scottish-fold-cats-1071855__480.jpg
-https://cdn.pixabay.com/photo/2014/11/18/08/11/cats-535789__480.jpg
 https://cdn.pixabay.com/photo/2013/11/21/11/11/cat-214628__480.jpg
 https://cdn.pixabay.com/photo/2013/11/28/10/02/cat-219960__480.jpg
 https://cdn.pixabay.com/photo/2014/03/06/22/00/cat-281258__480.jpg
@@ -630,10 +604,8 @@ https://cdn.pixabay.com/photo/2017/04/30/18/49/cat-2273618__480.jpg
 https://cdn.pixabay.com/photo/2017/01/30/12/01/cats-2020654__480.jpg
 https://cdn.pixabay.com/photo/2017/05/14/09/49/cat-2311632__480.jpg
 https://cdn.pixabay.com/photo/2017/05/15/21/19/himalayan-2316115__480.jpg
-https://cdn.pixabay.com/photo/2017/04/30/12/56/british-2272797__480.jpg
 https://cdn.pixabay.com/photo/2016/10/10/15/02/cat-1728601__480.jpg
 https://cdn.pixabay.com/photo/2017/03/27/21/29/cat-2180327__480.jpg
-https://cdn.pixabay.com/photo/2017/05/11/10/25/cat-2303670__480.jpg
 https://cdn.pixabay.com/photo/2017/01/13/19/29/cat-1978087__480.jpg
 https://cdn.pixabay.com/photo/2017/03/08/15/33/cat-2127080__480.jpg
 https://cdn.pixabay.com/photo/2017/02/04/13/02/cat-2037306__480.jpg
@@ -684,7 +656,6 @@ https://cdn.pixabay.com/photo/2016/11/17/13/27/cat-1831539__480.jpg
 https://cdn.pixabay.com/photo/2016/09/27/21/27/cat-1699351__480.jpg
 https://cdn.pixabay.com/photo/2016/11/24/16/49/cat-1856701__480.jpg
 https://cdn.pixabay.com/photo/2017/02/17/18/25/cat-2074779__480.jpg
-https://cdn.pixabay.com/photo/2017/05/11/10/26/small-cat-2303680__480.jpg
 https://cdn.pixabay.com/photo/2017/05/07/23/08/cat-2293957__480.jpg
 https://cdn.pixabay.com/photo/2017/03/05/13/28/cat-2118648__480.jpg
 https://cdn.pixabay.com/photo/2017/04/28/20/00/cat-2269310__480.jpg
@@ -801,7 +772,6 @@ https://cdn.pixabay.com/photo/2016/01/14/00/28/cat-1139148__480.jpg
 https://cdn.pixabay.com/photo/2016/01/24/09/34/cat-1158610__480.jpg
 https://cdn.pixabay.com/photo/2016/01/16/14/36/cat-1143463__480.jpg
 https://cdn.pixabay.com/photo/2017/05/13/09/49/cat-2309132__480.jpg
-https://cdn.pixabay.com/photo/2016/06/19/17/15/cat-1467203__480.jpg
 https://cdn.pixabay.com/photo/2016/06/29/21/50/cat-1487875__480.jpg
 https://cdn.pixabay.com/photo/2016/12/01/10/23/cat-1874948__480.jpg
 https://cdn.pixabay.com/photo/2015/04/15/00/50/cat-723032__480.jpg
@@ -813,11 +783,9 @@ https://cdn.pixabay.com/photo/2016/05/16/23/38/animal-1397157__480.jpg
 https://cdn.pixabay.com/photo/2016/04/05/18/27/cat-1309877__480.jpg
 https://cdn.pixabay.com/photo/2015/11/05/09/41/cat-1023935__480.jpg
 https://cdn.pixabay.com/photo/2017/02/15/00/08/cat-2067369__480.jpg
-https://cdn.pixabay.com/photo/2015/12/23/23/58/cat-1106340__480.jpg
 https://cdn.pixabay.com/photo/2016/11/23/13/53/cats-1852986__480.jpg
 https://cdn.pixabay.com/photo/2015/07/30/18/27/small-cat-868155__480.jpg
 https://cdn.pixabay.com/photo/2015/10/24/07/42/cat-1004098__480.jpg
-https://cdn.pixabay.com/photo/2016/05/19/04/44/cat-1402170__480.jpg
 https://cdn.pixabay.com/photo/2015/03/10/18/45/pet-667560__480.jpg
 https://cdn.pixabay.com/photo/2016/01/20/10/42/cat-1151262__480.jpg
 https://cdn.pixabay.com/photo/2016/06/29/16/35/cat-1487243__480.jpg
@@ -830,7 +798,6 @@ https://cdn.pixabay.com/photo/2015/09/18/21/21/cat-946437__480.jpg
 https://cdn.pixabay.com/photo/2016/05/16/23/00/kitten-1397070__480.jpg
 https://cdn.pixabay.com/photo/2016/11/04/13/40/cat-1797805__480.jpg
 https://cdn.pixabay.com/photo/2016/01/12/11/31/sam-jacks-1135210__480.jpg
-https://cdn.pixabay.com/photo/2016/08/30/13/27/cat-animal-1630750__480.jpg
 https://cdn.pixabay.com/photo/2015/04/02/00/50/cat-703227__480.jpg
 https://cdn.pixabay.com/photo/2016/12/21/16/37/cat-1923318__480.jpg
 https://cdn.pixabay.com/photo/2016/08/28/12/39/kitten-1625850__480.jpg
@@ -858,7 +825,6 @@ https://cdn.pixabay.com/photo/2016/05/26/17/33/cat-1417662__480.jpg
 https://cdn.pixabay.com/photo/2015/01/22/17/07/cat-608001__480.jpg
 https://cdn.pixabay.com/photo/2016/04/19/14/33/cat-1338745__480.jpg
 https://cdn.pixabay.com/photo/2014/02/28/23/11/cat-277273__480.jpg
-https://cdn.pixabay.com/photo/2017/06/04/20/29/black-cat-2372146__480.jpg
 https://cdn.pixabay.com/photo/2016/10/08/06/59/cat-1723144__480.jpg
 https://cdn.pixabay.com/photo/2017/05/19/14/58/cat-2326730__480.jpg
 https://cdn.pixabay.com/photo/2016/05/30/16/12/cat-1425097__480.jpg
@@ -871,7 +837,6 @@ https://cdn.pixabay.com/photo/2016/08/09/08/36/cat-1580122__480.jpg
 https://cdn.pixabay.com/photo/2015/04/13/23/17/cat-721424__480.jpg
 https://cdn.pixabay.com/photo/2014/11/08/04/20/cat-521557__480.jpg
 https://cdn.pixabay.com/photo/2015/12/03/22/41/cat-1075869__480.jpg
-https://cdn.pixabay.com/photo/2016/10/12/00/59/black-cat-1733253__480.jpg
 https://cdn.pixabay.com/photo/2016/03/15/18/44/cat-1258945__480.jpg
 https://cdn.pixabay.com/photo/2014/06/11/20/43/cats-367057__480.jpg
 https://cdn.pixabay.com/photo/2016/01/27/19/31/cat-1165176__480.jpg
@@ -904,7 +869,6 @@ https://cdn.pixabay.com/photo/2016/03/09/19/52/cat-1247278__480.jpg
 https://cdn.pixabay.com/photo/2015/02/05/18/22/cat-625270__480.jpg
 https://cdn.pixabay.com/photo/2016/05/12/11/27/cat-1387522__480.jpg
 https://cdn.pixabay.com/photo/2016/09/28/11/47/cat-1700299__480.jpg
-https://cdn.pixabay.com/photo/2016/01/20/02/29/cat-1150752__480.jpg
 https://cdn.pixabay.com/photo/2015/02/03/09/50/cat-622212__480.jpg
 https://cdn.pixabay.com/photo/2016/04/22/00/02/cat-1344854__480.jpg
 https://cdn.pixabay.com/photo/2016/06/27/17/15/cat-1482889__480.jpg
@@ -917,11 +881,9 @@ https://cdn.pixabay.com/photo/2016/10/16/20/56/mainecoon-1746222__480.jpg
 https://cdn.pixabay.com/photo/2016/01/30/16/12/cat-1169924__480.jpg
 https://cdn.pixabay.com/photo/2015/01/14/09/12/cat-598922__480.jpg
 https://cdn.pixabay.com/photo/2016/06/24/06/51/cat-1476771__480.jpg
-https://cdn.pixabay.com/photo/2015/01/21/17/16/animal-606959__480.jpg
 https://cdn.pixabay.com/photo/2017/06/15/15/06/cat-2405673__480.jpg
 https://cdn.pixabay.com/photo/2014/12/16/22/10/cat-570846__480.jpg
 https://cdn.pixabay.com/photo/2016/08/02/19/00/cat-1564496__480.jpg
-https://cdn.pixabay.com/photo/2016/05/26/04/51/cat-1416467__480.jpg
 https://cdn.pixabay.com/photo/2013/07/22/17/16/cat-166077__480.jpg
 https://cdn.pixabay.com/photo/2015/08/31/20/28/cat-916055__480.jpg
 https://cdn.pixabay.com/photo/2014/12/15/16/54/cat-569271__480.jpg
@@ -961,7 +923,6 @@ https://cdn.pixabay.com/photo/2015/09/26/22/22/cat-959899__480.jpg
 https://cdn.pixabay.com/photo/2015/03/20/20/27/cat-682820__480.jpg
 https://cdn.pixabay.com/photo/2015/09/10/09/23/cat-934257__480.jpg
 https://cdn.pixabay.com/photo/2016/02/21/14/03/cat-1213623__480.jpg
-https://cdn.pixabay.com/photo/2015/04/11/05/21/cat-717267__480.jpg
 https://cdn.pixabay.com/photo/2015/02/25/16/50/cat-649058__480.jpg
 https://cdn.pixabay.com/photo/2015/05/24/12/03/cat-781678__480.jpg
 https://cdn.pixabay.com/photo/2017/04/23/13/53/cat-2253839__480.jpg
@@ -978,7 +939,6 @@ https://cdn.pixabay.com/photo/2014/10/06/12/56/cat-476281__480.jpg
 https://cdn.pixabay.com/photo/2016/03/27/19/13/scared-1283751__480.jpg
 https://cdn.pixabay.com/photo/2013/10/20/10/39/cat-198343__480.jpg
 https://cdn.pixabay.com/photo/2016/04/04/14/32/cat-1307331__480.jpg
-https://cdn.pixabay.com/photo/2016/08/18/20/22/kittens-1603818__480.jpg
 https://cdn.pixabay.com/photo/2014/12/03/20/00/cat-555784__480.jpg
 https://cdn.pixabay.com/photo/2014/05/21/14/42/cat-349649__480.jpg
 https://cdn.pixabay.com/photo/2016/03/29/22/50/cats-1289625__480.jpg
@@ -992,7 +952,6 @@ https://cdn.pixabay.com/photo/2015/04/09/11/20/cat-714358__480.jpg
 https://cdn.pixabay.com/photo/2014/09/03/16/23/cat-434707__480.jpg
 https://cdn.pixabay.com/photo/2015/03/02/19/56/cute-656489__480.jpg
 https://cdn.pixabay.com/photo/2016/02/03/16/40/cat-1177419__480.jpg
-https://cdn.pixabay.com/photo/2015/03/06/14/11/cat-661739__480.jpg
 https://cdn.pixabay.com/photo/2014/09/22/18/05/cat-456615__480.jpg
 https://cdn.pixabay.com/photo/2014/09/14/19/42/cat-445347__480.jpg
 https://cdn.pixabay.com/photo/2017/06/17/19/22/cat-2413264__480.jpg
@@ -1005,12 +964,10 @@ https://cdn.pixabay.com/photo/2016/08/17/21/50/cat-1601613__480.jpg
 https://cdn.pixabay.com/photo/2017/05/17/06/31/cat-2320049__480.jpg
 https://cdn.pixabay.com/photo/2014/09/12/14/27/cat-442818__480.jpg
 https://cdn.pixabay.com/photo/2014/02/03/20/19/cat-257575__480.jpg
-https://cdn.pixabay.com/photo/2015/04/11/05/24/cat-717269__480.jpg
 https://cdn.pixabay.com/photo/2015/12/10/11/38/gata-1086278__480.jpg
 https://cdn.pixabay.com/photo/2015/12/17/21/41/cat-1097892__480.jpg
 https://cdn.pixabay.com/photo/2014/09/07/19/18/cat-438220__480.jpg
 https://cdn.pixabay.com/photo/2015/05/10/20/06/cat-761507__480.jpg
-https://cdn.pixabay.com/photo/2015/02/18/03/39/cat-640270__480.jpg
 https://cdn.pixabay.com/photo/2013/07/05/15/47/cat-143501__480.jpg
 https://cdn.pixabay.com/photo/2016/02/12/01/36/cat-1195289__480.jpg
 https://cdn.pixabay.com/photo/2014/11/16/10/17/kitten-533242__480.jpg
@@ -1028,7 +985,6 @@ https://cdn.pixabay.com/photo/2015/05/28/19/49/black-cat-788383__480.jpg
 https://cdn.pixabay.com/photo/2015/03/11/16/35/kittens-668875__480.jpg
 https://cdn.pixabay.com/photo/2014/12/20/18/58/cat-574256__480.jpg
 https://cdn.pixabay.com/photo/2014/05/25/14/50/cat-353735__480.jpg
-https://cdn.pixabay.com/photo/2016/03/06/07/17/kitten-sleeping-1239802__480.jpg
 https://cdn.pixabay.com/photo/2017/05/21/22/02/cat-2332437__480.jpg
 https://cdn.pixabay.com/photo/2015/03/12/17/48/cat-670550__480.jpg
 https://cdn.pixabay.com/photo/2015/04/17/13/59/cat-727263__480.jpg
@@ -1086,8 +1042,6 @@ https://cdn.pixabay.com/photo/2014/03/30/14/33/cat-301458__480.jpg
 https://cdn.pixabay.com/photo/2015/12/24/15/46/cat-1106935__480.jpg
 https://cdn.pixabay.com/photo/2015/09/26/18/35/white-grey-cat-959478__480.jpg
 https://cdn.pixabay.com/photo/2013/08/30/16/31/cat-177491__480.jpg
-https://cdn.pixabay.com/photo/2013/04/06/15/17/hangover-101075__480.jpg
-https://cdn.pixabay.com/photo/2014/12/03/20/47/hangover-555806__480.jpg
 https://cdn.pixabay.com/photo/2015/03/17/13/18/cat-677693__480.jpg
 https://cdn.pixabay.com/photo/2014/10/26/22/46/cat-504549__480.jpg
 https://cdn.pixabay.com/photo/2014/09/09/21/20/cat-440404__480.jpg
@@ -1095,14 +1049,12 @@ https://cdn.pixabay.com/photo/2015/08/24/16/59/cat-905245__480.jpg
 https://cdn.pixabay.com/photo/2015/09/30/15/35/fauna-965643__480.jpg
 https://cdn.pixabay.com/photo/2016/08/20/21/13/cat-1608577__480.jpg
 https://cdn.pixabay.com/photo/2015/09/22/14/47/cat-951801__480.jpg
-https://cdn.pixabay.com/photo/2014/04/05/22/00/hangover-317378__480.jpg
 https://cdn.pixabay.com/photo/2015/12/27/18/25/kitten-1110126__480.jpg
 https://cdn.pixabay.com/photo/2014/05/08/18/25/cat-puppy-340379__480.jpg
 https://cdn.pixabay.com/photo/2016/05/17/19/07/cat-1398834__480.jpg
 https://cdn.pixabay.com/photo/2013/09/05/16/17/cat-179194__480.jpg
 https://cdn.pixabay.com/photo/2014/12/20/19/20/surprise-574281__480.jpg
 https://cdn.pixabay.com/photo/2014/05/05/17/12/sacred-birman-338329__480.jpg
-https://cdn.pixabay.com/photo/2014/12/15/07/01/kitten-568705__480.jpg
 https://cdn.pixabay.com/photo/2016/12/15/04/43/gata-1908083__480.jpg
 https://cdn.pixabay.com/photo/2014/10/17/08/20/cat-492020__480.jpg
 https://cdn.pixabay.com/photo/2014/08/11/14/48/cat-415630__480.jpg
@@ -1131,13 +1083,10 @@ https://cdn.pixabay.com/photo/2014/09/18/16/06/cat-451076__480.jpg
 https://cdn.pixabay.com/photo/2013/11/01/09/50/hangover-203822__480.jpg
 https://cdn.pixabay.com/photo/2014/09/22/16/31/cat-456463__480.jpg
 https://cdn.pixabay.com/photo/2014/08/19/13/00/cat-421476__480.jpg
-https://cdn.pixabay.com/photo/2014/12/16/05/24/kitten-569951__480.jpg
 https://cdn.pixabay.com/photo/2015/06/26/21/06/cat-822907__480.jpg
 https://cdn.pixabay.com/photo/2015/03/20/12/55/cat-682179__480.jpg
-https://cdn.pixabay.com/photo/2014/11/16/20/31/abyssinian-533921__480.jpg
 https://cdn.pixabay.com/photo/2014/01/30/14/01/british-longhair-cat-254928__480.jpg
 https://cdn.pixabay.com/photo/2015/09/30/09/43/cat-965174__480.jpg
-https://cdn.pixabay.com/photo/2015/02/13/23/08/hangover-635932__480.jpg
 https://cdn.pixabay.com/photo/2013/01/24/12/34/cat-75996__480.jpg
 https://cdn.pixabay.com/photo/2016/03/30/20/16/cat-1291482__480.jpg
 https://cdn.pixabay.com/photo/2014/06/12/00/44/cat-367222__480.jpg
@@ -1146,19 +1095,15 @@ https://cdn.pixabay.com/photo/2014/09/13/05/09/paw-443605__480.jpg
 https://cdn.pixabay.com/photo/2013/07/25/10/49/cat-166813__480.jpg
 https://cdn.pixabay.com/photo/2014/12/12/13/46/cat-565467__480.jpg
 https://cdn.pixabay.com/photo/2014/03/09/23/20/kurilian-bobtail-284187__480.jpg
-https://cdn.pixabay.com/photo/2015/03/06/23/09/hangover-662465__480.jpg
 https://cdn.pixabay.com/photo/2013/11/23/01/06/adorable-216165__480.jpg
 https://cdn.pixabay.com/photo/2015/02/10/16/42/cat-631248__480.jpg
 https://cdn.pixabay.com/photo/2017/04/26/17/30/cat-2263107__480.jpg
-https://cdn.pixabay.com/photo/2015/08/03/14/45/kitten-873392__480.jpg
 https://cdn.pixabay.com/photo/2014/04/05/11/21/grey-315326__480.jpg
 https://cdn.pixabay.com/photo/2013/08/12/00/24/cat-171706__480.jpg
 https://cdn.pixabay.com/photo/2013/02/11/08/09/cat-80444__480.jpg
 https://cdn.pixabay.com/photo/2016/01/25/03/11/lil-man-1159987__480.jpg
 https://cdn.pixabay.com/photo/2014/02/13/19/32/cat-265592__480.jpg
 https://cdn.pixabay.com/photo/2016/01/10/22/25/cats-1132651__480.jpg
-https://cdn.pixabay.com/photo/2016/07/28/15/32/maine-coon-1548244__480.jpg
-https://cdn.pixabay.com/photo/2014/11/16/04/26/korat-533037__480.jpg
 https://cdn.pixabay.com/photo/2014/08/03/00/02/siamese-cat-408761__480.jpg
 https://cdn.pixabay.com/photo/2014/12/20/19/14/cat-574276__480.jpg
 https://cdn.pixabay.com/photo/2017/06/17/08/31/kitten-2411536__480.jpg

--- a/classified-cat-jp-images.txt
+++ b/classified-cat-jp-images.txt
@@ -18,6 +18,7 @@ https://cdn.pixabay.com/photo/2017/05/21/22/06/cat-2332444__480.jpg
 https://cdn.pixabay.com/photo/2014/03/30/23/35/cat-301720__480.jpg
 https://cdn.pixabay.com/photo/2017/05/21/22/07/cat-2332451__480.jpg
 https://cdn.pixabay.com/photo/2014/08/03/00/51/kitten-408798__480.jpg
+https://cdn.pixabay.com/photo/2017/05/11/07/27/cat-2303146__480.jpg
 https://cdn.pixabay.com/photo/2014/03/30/23/49/cat-301723__480.jpg
 https://cdn.pixabay.com/photo/2013/07/18/20/27/cat-165068__480.jpg
 https://cdn.pixabay.com/photo/2017/05/25/07/40/cat-2342562__480.jpg


### PR DESCRIPTION
I just iterated through the original and removed all the 403s with this simple script:
```py
from requests import get

with open('classified-cat-jp-images.txt ', 'r') as cats:
    valid_urls = [line for line in cats if get(line.strip())]

with open('classified-cat-jp-images_cats_fixed.txt', 'w') as cats:
    cats.write(''.join(valid_urls))```